### PR TITLE
Add CI workflow for multiplatform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: CI Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  jvm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Grant execute permission
+        run: chmod +x gradlew
+      - name: Build JVM
+        run: ./gradlew jvmJar --stacktrace
+      - name: Run JVM
+        run: ./gradlew jvmRun --stacktrace
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Grant execute permission
+        run: chmod +x gradlew
+      - name: Build Android
+        run: ./gradlew assembleDebug --stacktrace
+
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Grant execute permission
+        run: chmod +x gradlew
+      - name: Build iOS
+        run: ./gradlew linkDebugFrameworkIosX64 --stacktrace
+
+  js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Grant execute permission
+        run: chmod +x gradlew
+      - name: Build JS
+        run: ./gradlew jsBrowserProductionWebpack --stacktrace

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Android | iOS | Web | Windows | MacOS | Linux (In Progress)
 ### iOS Run
 Just launch xcode workspace as usual
 
+### Continuous Integration
+CI is configured with GitHub Actions. Every pull request to the `main`
+branch triggers builds for Android, JVM, iOS and JavaScript targets to
+ensure the project compiles and runs without errors on each platform.
+
 ### Youtube support
 
 All this code has video support on YouTube (only in Russian)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds the Android, JVM, iOS and JS targets
- document workflow in README
- make the workflow run only on pull requests to `main`

## Testing
- `./gradlew --version` *(fails: No route to host)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.