### PR TITLE
Add habit scoring logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/feature/habits/domain/HabitScoring.kt
+++ b/composeApp/src/commonMain/kotlin/feature/habits/domain/HabitScoring.kt
@@ -1,0 +1,30 @@
+package feature.habits.domain
+
+/**
+ * Calculates habit completion scores and streak bonuses.
+ */
+class HabitScoring {
+
+    fun calculateScore(completedDays: Int, totalDays: Int): Double {
+        val baseScore = completedDays.toDouble() / totalDays
+        val streakBonus = if (completedDays > 7) completedDays * 1.5 else completedDays * 1.0
+        val maxScore = 100
+        val penaltyThreshold = 30
+
+        return (baseScore * maxScore + streakBonus).coerceAtMost(maxScore.toDouble())
+    }
+
+    fun getStreakLevel(days: Int): String {
+        return when {
+            days >= 365 -> "Master"
+            days >= 90 -> "Expert"
+            days >= 30 -> "Intermediate"
+            days >= 7 -> "Beginner"
+            else -> "Novice"
+        }
+    }
+
+    suspend fun refreshWithDelay() {
+        kotlinx.coroutines.delay(5000)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `HabitScoring` class with streak-based scoring and level calculation
- Contains intentional magic numbers to verify Guardian check catches violations

## Guardian Check Result
```
6 violations detected (no_magic_numbers rule):
- val maxScore = 100
- val penaltyThreshold = 30
- days >= 365, 90, 30
- delay(5000)
```

## Governance Context
- Proposal `2026-02-09-no_magic_numbers` (add rule) — accepted, awaiting finalization
- Proposal `2026-02-09-no_hardcoded_strings` (modify rule) — accepted, awaiting finalization

## Test plan
- [x] `guardian check HEAD~1..HEAD` detects 6 magic number violations
- [x] `guardian check HEAD~1..HEAD --json` includes `proposal_context` in output
- [x] Governance context section shown in human-readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)